### PR TITLE
Set SRCREV & SRCREV_machine In linux-yocto_3.14.bb To AUTOREV

### DIFF
--- a/recipes-kernel/linux/linux-yocto_3.14.bb
+++ b/recipes-kernel/linux/linux-yocto_3.14.bb
@@ -8,8 +8,8 @@ KMETA = ""
 
 SRC_URI = "git://github.com/vtss/linux-stable.git;protocol=git;bareclone=1;branch=${KBRANCH}"
 
-SRCREV                = "b04a6112a8001462b0af176f7dc8c934aa77ba2c"
-SRCREV_machine        = "b04a6112a8001462b0af176f7dc8c934aa77ba2c"
+SRCREV                = "${AUTOREV}"
+SRCREV_machine        = "${AUTOREV}"
 
 PR = "r1"
 PV = "${LINUX_VERSION}+git${SRCPV}"


### PR DESCRIPTION
The linux-yocto_3.14.bb file refences a changeset ID
b04a6112a8001462b0af176f7dc8c934aa77ba2c which does not exist in
git://github.com/vtss/linux-stable.git  This causes bitbake attempt to
fail with the error messsage:
Unable to find revision b04a6112a8001462b0af176f7dc8c934aa77ba2c in
branch vtss_3.14 even from upstream

This change replaced the reference to b04a6112 with ${AUTOREV} which
should always point to the head revision of the target repository.  With
this change in place `bitbake linux-yocto` completes successfully.

Setting the current head revision (fcd1c9cb) fails with a new error.  The
expected values for SRCREV and SRCREV_machine are to an annotated tag or
to a changeset ID which corresponds to an annotated tag.

For further details please see issue vtss/meta-vtss-switch#1